### PR TITLE
Remove lowercasing from Imbo DSL -> AST transformation (Issue #12)

### DIFF
--- a/library/Dsl/Parser.php
+++ b/library/Dsl/Parser.php
@@ -67,39 +67,11 @@ class Parser {
             throw new \InvalidArgumentException('Query must be a JSON object or array', 400);
         }
 
-        $query = self::lowercase($json);
-
-        $normalizedQuery = self::normalizeExpression($query);
+        $normalizedQuery = self::normalizeExpression($json);
 
         $ast = self::convertQueryToAst($normalizedQuery);
 
         return $ast;
-    }
-
-    /**
-     * Lowercases a query
-     *
-     * This method will lowercase all field names and values to make the search case insensitive.
-     *
-     * @param array $query The metadata query from the query string
-     * @return array
-     */
-    private static function lowercase(array $query) {
-        $result = array();
-
-        foreach ($query as $key => $value) {
-            $key = strtolower($key);
-
-            if (is_array($value)) {
-                $value = self::lowercase($value);
-            } else if (is_string($value)) {
-                $value = mb_strtolower($value, 'UTF-8');
-            }
-
-            $result[$key] = $value;
-        }
-
-        return $result;
     }
 
     /**

--- a/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/ParserTest.php
+++ b/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/ParserTest.php
@@ -74,6 +74,13 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
                                   new Field('foo', new LessThanEquals(15)),
                               ])
             ),
+            'in and not-in is accepted with arrays' => array(
+                'original' => '{"$or": [{"field": {"$in": [1, 2, 3]}}, {"field": {"$nin": [5, 6 ,7]}}]}',
+                'expected' => new Disjunction([
+                                  new Field('field', new In([1, 2, 3])),
+                                  new Field('field', new NotIn([5, 6, 7])),
+                              ])
+            ),
             'a larger, more complex query' => array(
                 'original' => '{
                                 "name": { "$ne": "Wit" },
@@ -126,6 +133,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
             'using an operator that is not supported ($regex)' => array(
                 'query' => array('category' => array('$regex' => '(foo|bar|baz)')),
                 'message' => 'Operator of the type $regex not allowed',
+            ),
+            'specifying a non-array for a operator' => array(
+                'query' => '{"$or": 3}',
+                'message' => 'Contents of the $or-expression is not an array',
             ),
             'not specifing an operator on a field' => array(
                 'query' => '{"category": []}',

--- a/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/ParserTest.php
+++ b/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/ParserTest.php
@@ -37,7 +37,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
             ),
             'mixed case' => array(
                 'original' => array('Foo' => 'Bar'),
-                'expected' => new Field('foo', new Equals('bar')),
+                'expected' => new Field('Foo', new Equals('Bar')),
             ),
             'implicit $and at the root, as string' => array(
                 'original' => '{"foo": "bar", "baz": "blargh"}',
@@ -87,13 +87,13 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
                                 ]
                                }',
                 'expected' => new Conjunction([
-                                  new Field('name', new NotEquals('wit')),
+                                  new Field('name', new NotEquals('Wit')),
                                   new Disjunction([
-                                      new Field('brewery', new Equals('nøgne ø')),
+                                      new Field('brewery', new Equals('Nøgne Ø')),
                                       new Conjunction([
                                           new Field('abv', new GreaterThanEquals(5.5)),
-                                          new Field('style', new In(['ipa', 'imperial stout'])),
-                                          new Field('brewery', new In(['haandbryggeriet', 'ægir'])),
+                                          new Field('style', new In(['IPA', 'Imperial Stout'])),
+                                          new Field('brewery', new In(['HaandBryggeriet', 'Ægir'])),
                                       ]),
                                   ]),
                               ]),


### PR DESCRIPTION
This PR fixes Issue #12, by removing the lowercasing of search terms.

It also adds some test-cases to bump up the code-coverage, as I realised that a few things wasn't tested.