### PR TITLE
Change the ES DSL-transformation to prefix fieldnames with metadata.

### DIFF
--- a/library/Dsl/Transformations/ElasticSearchDsl.php
+++ b/library/Dsl/Transformations/ElasticSearchDsl.php
@@ -59,7 +59,7 @@ class ElasticSearchDsl implements DslTransformationInterface {
                 // We have a field, so let's look at the type of comparison we
                 // are making, to determine how to transform it into a ES-php
                 // DSL query
-                $field = $query->field();
+                $field = 'metadata.' . $query->field();
                 $comparison = $query->comparison();
 
                 switch (true) {

--- a/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/Transformations/ElasticSearchDslTest.php
+++ b/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/Transformations/ElasticSearchDslTest.php
@@ -16,18 +16,18 @@ class ElasticSearchDslTest extends \PHPUnit_Framework_TestCase {
         return array(
             'a simple query' => array(
                 'query' => '{"foo": "bar"}',
-                'expected' => array('query' => array('match' => array('foo' => 'bar'))),
+                'expected' => array('query' => array('match' => array('metadata.foo' => 'bar'))),
             ),
             'another simple query' => array(
                 'query' => '{"foo": "bar", "baz": "blargh"}',
                 'expected' => array('filter' => array('and' => array(
-                                                        array('query' => array('match' => array('foo' => 'bar'))),
-                                                        array('query' => array('match' => array('baz' => 'blargh'))),
+                                                        array('query' => array('match' => array('metadata.foo' => 'bar'))),
+                                                        array('query' => array('match' => array('metadata.baz' => 'blargh'))),
                                                     ))),
             ),
             'a simple less-than query' => array(
                 'query' => '{"foo": {"$lt": 5}}',
-                'expected' => array('filter' => array('range' => array('foo' => array('lt' => 5)))),
+                'expected' => array('filter' => array('range' => array('metadata.foo' => array('lt' => 5)))),
             ),
         );
     }


### PR DESCRIPTION
Because we want the entire image stored in ES, we need to move the metadata entries into a sub-object in the ES document. This means that searches for any given metadata-fieldname, needs to have the filename prefixed with `metadata.`.

This PR simply adds `metadata.` in front of all fieldnames in the DSL transformation-step. The unit-tests have been updated to account for this.