### PR TITLE
Index full image documents

### DIFF
--- a/library/Backend/ElasticSearch.php
+++ b/library/Backend/ElasticSearch.php
@@ -33,8 +33,8 @@ class ElasticSearch implements SearchBackendInterface {
     /**
      * {@inheritdoc}
      */
-    public function set($publicKey, $imageIdentifier, array $metadata) {
-        $params = $this->prepareParams($publicKey, $imageIdentifier, $metadata);
+    public function set($publicKey, $imageIdentifier, array $imageData) {
+        $params = $this->prepareParams($publicKey, $imageIdentifier, $imageData);
 
         try {
             return !!$this->client->index($params);

--- a/library/EventListener/MetadataOperations.php
+++ b/library/EventListener/MetadataOperations.php
@@ -111,7 +111,7 @@ class MetadataOperations implements ListenerInterface {
     }
 
     /**
-     * Remove metadata (DELETE) handler
+     * Remove image information (DELETE) handler
      *
      * @param Imbo\EventListener\ListenerInterface $event The current event
      */

--- a/library/EventListener/MetadataOperations.php
+++ b/library/EventListener/MetadataOperations.php
@@ -8,7 +8,8 @@ use Imbo\EventListener\ListenerInterface,
     Imbo\MetadataSearch\Interfaces\SearchBackendInterface,
     Imbo\MetadataSearch\Dsl\Parser as DslParser,
     Imbo\Exception\RuntimeException,
-    Imbo\Model\Images as ImagesModel;
+    Imbo\Model\Images as ImagesModel,
+    Imbo\Model\Image as ImageModel;
 
 /**
  * Metadata event listener
@@ -35,29 +36,77 @@ class MetadataOperations implements ListenerInterface {
 
     public static function getSubscribedEvents() {
         return [
-            'metadata.post'   => ['set' => -1000],
-            'metadata.put'    => ['set' => -1000],
-            'metadata.delete' => ['delete' => -1000],
+            'image.delete' => ['delete' => -1000],
+            'images.post' => ['set' => -1000],
+            'image.post' => ['set' => -1000],
+            'metadata.post' => ['set' => -1000],
+            'metadata.put' => ['set' => -1000],
+            'metadata.delete' => ['set' => -1000],
             'metadata.search' => 'search',
         ];
     }
 
+    public function getImageData($event, $imageIdentifier) {
+        $image = new ImageModel();
+
+        $event->getDatabase()->load(
+            $event->getRequest()->getPublicKey(),
+            $imageIdentifier,
+            $image
+        );
+
+        // Get image metadata
+        $metadata = $event->getDatabase()->getMetadata(
+            $event->getRequest()->getPublicKey(),
+            $imageIdentifier
+        );
+
+        // Set image metadata on the image model
+        $image->setMetadata($metadata);
+
+        return $image;
+    }
+
     /**
-     * Update metadata for an image
+     * Update image data
      *
      * @param Imbo\EventListener\ListenerInterface $event The current event
      */
     public function set(EventInterface $event) {
         $request = $event->getRequest();
+        $response = $event->getResponse();
 
-        // Get the metadata set by imbo
-        $metadata = $event->getResponse()->getModel();
+        $imageIdentifier = $request->getImageIdentifier();
 
-        // Trigger update of metadata in search backend
+        // The imageIdentifier was not part of the URL
+        if (!$imageIdentifier) {
+            $responseData = $response->getModel()->getData();
+
+            if (!isset($responseData['imageIdentifier'])) {
+                return;
+            }
+
+            $imageIdentifier = $responseData['imageIdentifier'];
+        }
+
+        // Get image information
+        $image = $this->getImageData($event, $imageIdentifier);
+
+        // Pass image data to the search backend
         $this->backend->set(
             $request->getPublicKey(),
-            $request->getImageIdentifier(),
-            $metadata->getData()
+            $imageIdentifier,
+            [
+                'publicKey' => $request->getPublicKey(),
+                'size' => $image->getFilesize(),
+                'extension' => $image->getExtension(),
+                'mime' => $image->getMimeType(),
+                'metadata' => $image->getMetadata(),
+                'added' => $image->getAddedDate()->getTimestamp(),
+                'updated' => $image->getUpdatedDate()->getTimestamp(),
+                'width' => $image->getWidth(),
+                'height' => $image->getHeight(),
+            ]
         );
     }
 

--- a/library/Interfaces/SearchBackendInterface.php
+++ b/library/Interfaces/SearchBackendInterface.php
@@ -9,14 +9,14 @@ namespace Imbo\MetadataSearch\Interfaces;
  */
 interface SearchBackendInterface {
     /**
-     * Set metadata for an image in the metadata search backend
+     * Set data for an image in the search backend
      *
      * @param string $publicKey Public key the image belongs to
      * @param string $imageIdentifier Image identifier
-     * @param array $metadata Metadata array containing key value pairs
+     * @param array $imageData Image data array containing key value pairs
      * @return bool
      */
-    public function set($publicKey, $imageIdentifier, array $metadata);
+    public function set($publicKey, $imageIdentifier, array $imageData);
 
     /**
      * Delete metadata for an image in the metadata search backend

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -115,10 +115,10 @@ class FeatureContext extends RESTContext implements Context, SnippetAcceptingCon
         $retDoc = $this->elasticsearch->get($params);
 
         if ($metadata && !$retDoc) {
-            throw new \Exception('Image metadata for ' . $imageIdentifer . ' not found in ES');
+            throw new \Exception('Image ' . $imageIdentifer . ' not found in ES');
         }
 
-        Assertion::eq(json_encode($retDoc['_source']), (string) $metadata);
+        Assertion::eq(json_encode($retDoc['_source']['metadata']), (string) $metadata);
     }
 
     /**
@@ -126,23 +126,10 @@ class FeatureContext extends RESTContext implements Context, SnippetAcceptingCon
      */
     public function elasticsearchShouldNotHaveMetadataFor($imageIdentifer)
     {
-        $publicKey = 'publickey';
-
-        $params = [
-            'index' => 'metadatasearch_integration-' . $publicKey,
-            'type' => 'metadata',
-            'id' => $imageIdentifer
-        ];
-
-        try {
-            $this->elasticsearch->get($params);
-        } catch (\Exception $e) {
-            Assertion::eq(404, $e->getCode());
-
-            return;
-        }
-
-        throw new \Exception('Image metadata found for image ' . $imageIdentifer . ' in ES');
+        $this->elasticsearchShouldHaveTheFollowingMetadataFor(
+            $imageIdentifer,
+            new PyStringNode(['[]'], null)
+        );
     }
 
     /**


### PR DESCRIPTION
In order to make sorting/filtering possible, we need more information in the search backend. 

This PR change the event hook list and now updates data in the search backend on image create, delete in addition to metadata updates.