### PR TITLE
Add sort support

### DIFF
--- a/library/Backend/ElasticSearch.php
+++ b/library/Backend/ElasticSearch.php
@@ -69,10 +69,14 @@ class ElasticSearch implements SearchBackendInterface {
         // Transform AST to ES query
         $query = $astTransformer->transform($ast);
 
+        // Get sort array
+        $sort = isset($queryParams['sort']) ? $queryParams['sort'] : [];
+
         $params = $this->prepareParams(
             $publicKey,
             null,
-            $query
+            $query,
+            $sort
         );
 
         $params['from'] = ($queryParams['page'] - 1) * $queryParams['limit'];
@@ -96,10 +100,11 @@ class ElasticSearch implements SearchBackendInterface {
      * @param array $metadata
      * @return array
      */
-    protected function prepareParams($publicKey, $imageIdentifier = null, $body = null) {
+    protected function prepareParams($publicKey, $imageIdentifier = null, $body = null, $sort = []) {
         $params = [
             'index' => $this->getIndexName($publicKey),
-            'type' => 'metadata'
+            'type' => 'metadata',
+            'body' => []
         ];
 
         if ($imageIdentifier !== null) {
@@ -107,7 +112,11 @@ class ElasticSearch implements SearchBackendInterface {
         }
 
         if ($body !== null) {
-            $params['body'] = $body;
+            $params['body'] = array_merge($params['body'], $body);
+        }
+
+        if ($sort) {
+            $params['body']['sort'] = $sort;
         }
 
         return $params;

--- a/library/EventListener/MetadataOperations.php
+++ b/library/EventListener/MetadataOperations.php
@@ -90,6 +90,42 @@ class MetadataOperations implements ListenerInterface {
     }
 
     /**
+     * Get sort params from request
+     *
+     * @param Imbo\EventListener\ListenerInterface $event The current event
+     * @return array
+     */
+    public function getSortParams(EventInterface $event) {
+        $params = $event->getRequest()->query;
+
+        // Get sort param from query
+        $sortParams = $params->get('sort', []);
+
+        // Split and sanitize sort params
+        $sortParams = array_map(function($param) {
+            $paramValues = explode(':', $param);
+
+            if (!$paramValues[0]) {
+                return false;
+            }
+
+            $key = $paramValues[0];
+            $dir = isset($paramValues[1]) ? $paramValues[1] : 'asc';
+
+            if (!in_array($dir, ['asc', 'desc'])) {
+                $dir = 'asc';
+            }
+
+            return [$key => $dir];
+        }, $sortParams);
+
+        // Filter empty keys
+        $sortParams = array_filter($sortParams);
+
+        return $sortParams;
+    }
+
+    /**
      * Update image data
      *
      * @param Imbo\EventListener\ListenerInterface $event The current event
@@ -178,6 +214,7 @@ class MetadataOperations implements ListenerInterface {
             'limit' => $params->get('limit', 20),
             'from' => $params->get('from'),
             'to' => $params->get('to'),
+            'sort' => $this->getSortParams($event),
         ];
 
         if ($queryParams['page'] < 1) {

--- a/tests/behat/bootstrap/RESTContext.php
+++ b/tests/behat/bootstrap/RESTContext.php
@@ -259,4 +259,19 @@ class RESTContext implements Context
     {
         $this->queryParams[$param] = $value;
     }
+
+    /**
+     * @Given /^I sort by (.*)$/
+     */
+    public function setSortParam($sortParams) {
+        $sortParams = json_decode($sortParams, true);
+
+        $sortArray = [];
+
+        foreach ($sortParams as $key => $dir) {
+            $sortArray[] = sprintf('%s:%s', $key, $dir);
+        }
+
+        $this->iSetTheQueryParamTo('sort', $sortArray);
+    }
 }

--- a/tests/behat/features/elasticsearch.feature
+++ b/tests/behat/features/elasticsearch.feature
@@ -56,7 +56,7 @@ Feature: Use elasticsearch as search backend for the metadata search pluin
         | metadata                       | page | limit | imageIdentifers                                                   | hits |
         | {"animal":"Snake"}             | 1    | 20    |                                                                   | 0    |
         | {"animal":"Hedgehog"}          | 1    | 20    | ce3e8c3de4b67e8af5315be82ec36692                                  | 1    |
-        | {"color":"red"}                | 1    | 20    | 574e32fb252f3c157c9b31babb0868c2,d3712bb23cf4e191e65cf938d55e8982 | 2    |
+        | {"color":"red"}                | 1    | 20    | d3712bb23cf4e191e65cf938d55e8982,574e32fb252f3c157c9b31babb0868c2 | 2    |
         | {"color":"red"}                | 1    | 1     | d3712bb23cf4e191e65cf938d55e8982                                  | 2    |
         | {"color":"red"}                | 2    | 1     | 574e32fb252f3c157c9b31babb0868c2                                  | 2    |
         | {"animal":"Cat","color":"red"} | 1    | 20    | d3712bb23cf4e191e65cf938d55e8982                                  | 1    |

--- a/tests/behat/features/elasticsearch.feature
+++ b/tests/behat/features/elasticsearch.feature
@@ -72,5 +72,4 @@ Feature: Use elasticsearch as search backend for the metadata search pluin
         | sort                           | imageIdentifiers                                                  |
         | {"size":"asc"}                 | d3712bb23cf4e191e65cf938d55e8982,574e32fb252f3c157c9b31babb0868c2 |
         | {"size":"desc"}                | 574e32fb252f3c157c9b31babb0868c2,d3712bb23cf4e191e65cf938d55e8982 |
-        | {"size":"desc"}                | 574e32fb252f3c157c9b31babb0868c2,d3712bb23cf4e191e65cf938d55e8982 |
         | {"width":"desc","size":"desc"} | d3712bb23cf4e191e65cf938d55e8982,574e32fb252f3c157c9b31babb0868c2 |

--- a/tests/behat/features/elasticsearch.feature
+++ b/tests/behat/features/elasticsearch.feature
@@ -12,54 +12,54 @@ Feature: Use elasticsearch as search backend for the metadata search pluin
             | tests/fixtures/prairie-dog.jpg   | {"animal":"Dog"}                      |
         And I have flushed the elasticsearch transaction log
 
-#    Scenario: Updating metadata
-#        When I set the following metadata on an image with identifier "574e32fb252f3c157c9b31babb0868c2":
-#        """
-#        {"foo":"bar"}
-#        """
-#        Then I should get a response with "200 OK"
-#        And Elasticsearch should have the following metadata for "574e32fb252f3c157c9b31babb0868c2":
-#        """
-#        {"foo":"bar"}
-#        """
-#
-#    Scenario: Deleting metadata
-#        When I delete metadata from image "574e32fb252f3c157c9b31babb0868c2"
-#        Then I should get a response with "200 OK"
-#        And Elasticsearch should not have metadata for "574e32fb252f3c157c9b31babb0868c2"
-#
-#    Scenario: Patch metadata
-#        Given I patch the metadata of the image with identifier "3012ee0319a7f752ac615d8d86b63894" with:
-#        """
-#        {"foo": "bar"}
-#        """
-#        Then I should get a response with "200 OK"
-#        And Elasticsearch should have the following metadata for "3012ee0319a7f752ac615d8d86b63894":
-#        """
-#        {"animal":"Giant Panda","foo":"bar"}
-#        """
-#
-#    Scenario: Search without using an access token
-#        When I search for images using {"animal":"Snake"}
-#        Then I should get a response with "400 Missing access token"
-#
-#    Scenario Outline: Search using metadata queries
-#        Given I include an access token in the query
-#        And I set the "limit" query param to "<limit>"
-#        And I set the "page" query param to "<page>"
-#        When I search for images using <metadata>
-#        Then I should get a response with "200 OK"
-#        And I should get the <imageIdentifers> in the image response list
-#        And the hit count should be "<hits>"
-#
-#        Examples:
-#        | metadata                       | page | limit | imageIdentifers                                                   | hits |
-#        | {"animal":"Snake"}             | 1    | 20    |                                                                   | 0    |
-#        | {"animal":"Hedgehog"}          | 1    | 20    | ce3e8c3de4b67e8af5315be82ec36692                                  | 1    |
-#        | {"color":"red"}                | 1    | 20    | d3712bb23cf4e191e65cf938d55e8982,574e32fb252f3c157c9b31babb0868c2 | 2    |
-#        | {"color":"red"}                | 1    | 1     | d3712bb23cf4e191e65cf938d55e8982                                  | 2    |
-#        | {"color":"red"}                | 2    | 1     | 574e32fb252f3c157c9b31babb0868c2                                  | 2    |
-#        | {"animal":"Cat","color":"red"} | 1    | 20    | d3712bb23cf4e191e65cf938d55e8982                                  | 1    |
+    Scenario: Updating metadata
+        When I set the following metadata on an image with identifier "574e32fb252f3c157c9b31babb0868c2":
+        """
+        {"foo":"bar"}
+        """
+        Then I should get a response with "200 OK"
+        And Elasticsearch should have the following metadata for "574e32fb252f3c157c9b31babb0868c2":
+        """
+        {"foo":"bar"}
+        """
+
+    Scenario: Deleting metadata
+        When I delete metadata from image "574e32fb252f3c157c9b31babb0868c2"
+        Then I should get a response with "200 OK"
+        And Elasticsearch should not have metadata for "574e32fb252f3c157c9b31babb0868c2"
+
+    Scenario: Patch metadata
+        Given I patch the metadata of the image with identifier "3012ee0319a7f752ac615d8d86b63894" with:
+        """
+        {"foo": "bar"}
+        """
+        Then I should get a response with "200 OK"
+        And Elasticsearch should have the following metadata for "3012ee0319a7f752ac615d8d86b63894":
+        """
+        {"animal":"Giant Panda","foo":"bar"}
+        """
+
+    Scenario: Search without using an access token
+        When I search for images using {"animal":"Snake"}
+        Then I should get a response with "400 Missing access token"
+
+    Scenario Outline: Search using metadata queries
+        Given I include an access token in the query
+        And I set the "limit" query param to "<limit>"
+        And I set the "page" query param to "<page>"
+        When I search for images using <metadata>
+        Then I should get a response with "200 OK"
+        And I should get the <imageIdentifers> in the image response list
+        And the hit count should be "<hits>"
+
+        Examples:
+        | metadata                       | page | limit | imageIdentifers                                                   | hits |
+        | {"animal":"Snake"}             | 1    | 20    |                                                                   | 0    |
+        | {"animal":"Hedgehog"}          | 1    | 20    | ce3e8c3de4b67e8af5315be82ec36692                                  | 1    |
+        | {"color":"red"}                | 1    | 20    | d3712bb23cf4e191e65cf938d55e8982,574e32fb252f3c157c9b31babb0868c2 | 2    |
+        | {"color":"red"}                | 1    | 1     | d3712bb23cf4e191e65cf938d55e8982                                  | 2    |
+        | {"color":"red"}                | 2    | 1     | 574e32fb252f3c157c9b31babb0868c2                                  | 2    |
+        | {"animal":"Cat","color":"red"} | 1    | 20    | d3712bb23cf4e191e65cf938d55e8982                                  | 1    |
 
     Scenario Outline: Search and sort the search result
         Given I include an access token in the query

--- a/tests/behat/features/elasticsearch.feature
+++ b/tests/behat/features/elasticsearch.feature
@@ -12,51 +12,65 @@ Feature: Use elasticsearch as search backend for the metadata search pluin
             | tests/fixtures/prairie-dog.jpg   | {"animal":"Dog"}                      |
         And I have flushed the elasticsearch transaction log
 
-    Scenario: Updating metadata
-        When I set the following metadata on an image with identifier "574e32fb252f3c157c9b31babb0868c2":
-        """
-        {"foo":"bar"}
-        """
-        Then I should get a response with "200 OK"
-        And Elasticsearch should have the following metadata for "574e32fb252f3c157c9b31babb0868c2":
-        """
-        {"foo":"bar"}
-        """
+#    Scenario: Updating metadata
+#        When I set the following metadata on an image with identifier "574e32fb252f3c157c9b31babb0868c2":
+#        """
+#        {"foo":"bar"}
+#        """
+#        Then I should get a response with "200 OK"
+#        And Elasticsearch should have the following metadata for "574e32fb252f3c157c9b31babb0868c2":
+#        """
+#        {"foo":"bar"}
+#        """
+#
+#    Scenario: Deleting metadata
+#        When I delete metadata from image "574e32fb252f3c157c9b31babb0868c2"
+#        Then I should get a response with "200 OK"
+#        And Elasticsearch should not have metadata for "574e32fb252f3c157c9b31babb0868c2"
+#
+#    Scenario: Patch metadata
+#        Given I patch the metadata of the image with identifier "3012ee0319a7f752ac615d8d86b63894" with:
+#        """
+#        {"foo": "bar"}
+#        """
+#        Then I should get a response with "200 OK"
+#        And Elasticsearch should have the following metadata for "3012ee0319a7f752ac615d8d86b63894":
+#        """
+#        {"animal":"Giant Panda","foo":"bar"}
+#        """
+#
+#    Scenario: Search without using an access token
+#        When I search for images using {"animal":"Snake"}
+#        Then I should get a response with "400 Missing access token"
+#
+#    Scenario Outline: Search using metadata queries
+#        Given I include an access token in the query
+#        And I set the "limit" query param to "<limit>"
+#        And I set the "page" query param to "<page>"
+#        When I search for images using <metadata>
+#        Then I should get a response with "200 OK"
+#        And I should get the <imageIdentifers> in the image response list
+#        And the hit count should be "<hits>"
+#
+#        Examples:
+#        | metadata                       | page | limit | imageIdentifers                                                   | hits |
+#        | {"animal":"Snake"}             | 1    | 20    |                                                                   | 0    |
+#        | {"animal":"Hedgehog"}          | 1    | 20    | ce3e8c3de4b67e8af5315be82ec36692                                  | 1    |
+#        | {"color":"red"}                | 1    | 20    | d3712bb23cf4e191e65cf938d55e8982,574e32fb252f3c157c9b31babb0868c2 | 2    |
+#        | {"color":"red"}                | 1    | 1     | d3712bb23cf4e191e65cf938d55e8982                                  | 2    |
+#        | {"color":"red"}                | 2    | 1     | 574e32fb252f3c157c9b31babb0868c2                                  | 2    |
+#        | {"animal":"Cat","color":"red"} | 1    | 20    | d3712bb23cf4e191e65cf938d55e8982                                  | 1    |
 
-    Scenario: Deleting metadata
-        When I delete metadata from image "574e32fb252f3c157c9b31babb0868c2"
-        Then I should get a response with "200 OK"
-        And Elasticsearch should not have metadata for "574e32fb252f3c157c9b31babb0868c2"
-
-    Scenario: Patch metadata
-        Given I patch the metadata of the image with identifier "3012ee0319a7f752ac615d8d86b63894" with:
-        """
-        {"foo": "bar"}
-        """
-        Then I should get a response with "200 OK"
-        And Elasticsearch should have the following metadata for "3012ee0319a7f752ac615d8d86b63894":
-        """
-        {"animal":"Giant Panda","foo":"bar"}
-        """
-
-    Scenario: Search without using an access token
-        When I search for images using {"animal":"Snake"}
-        Then I should get a response with "400 Missing access token"
-
-    Scenario Outline: Search using metadata queries
+    Scenario Outline: Search and sort the search result
         Given I include an access token in the query
-        And I set the "limit" query param to "<limit>"
-        And I set the "page" query param to "<page>"
-        When I search for images using <metadata>
+        And I sort by <sort>
+        When I search for images using {"color":"red"}
         Then I should get a response with "200 OK"
-        And I should get the <imageIdentifers> in the image response list
-        And the hit count should be "<hits>"
+        And I should get the <imageIdentifiers> in the image response list
 
         Examples:
-        | metadata                       | page | limit | imageIdentifers                                                   | hits |
-        | {"animal":"Snake"}             | 1    | 20    |                                                                   | 0    |
-        | {"animal":"Hedgehog"}          | 1    | 20    | ce3e8c3de4b67e8af5315be82ec36692                                  | 1    |
-        | {"color":"red"}                | 1    | 20    | d3712bb23cf4e191e65cf938d55e8982,574e32fb252f3c157c9b31babb0868c2 | 2    |
-        | {"color":"red"}                | 1    | 1     | d3712bb23cf4e191e65cf938d55e8982                                  | 2    |
-        | {"color":"red"}                | 2    | 1     | 574e32fb252f3c157c9b31babb0868c2                                  | 2    |
-        | {"animal":"Cat","color":"red"} | 1    | 20    | d3712bb23cf4e191e65cf938d55e8982                                  | 1    |
+        | sort                           | imageIdentifiers                                                  |
+        | {"size":"asc"}                 | d3712bb23cf4e191e65cf938d55e8982,574e32fb252f3c157c9b31babb0868c2 |
+        | {"size":"desc"}                | 574e32fb252f3c157c9b31babb0868c2,d3712bb23cf4e191e65cf938d55e8982 |
+        | {"size":"desc"}                | 574e32fb252f3c157c9b31babb0868c2,d3712bb23cf4e191e65cf938d55e8982 |
+        | {"width":"desc","size":"desc"} | d3712bb23cf4e191e65cf938d55e8982,574e32fb252f3c157c9b31babb0868c2 |


### PR DESCRIPTION
This PR adds sorting support for search backend with normalization of search params and handling of these in the ES backend. Also adds force sort of response model images to force the order to match the one from the search backend.