### PR TITLE
Add support for filtering images by added timestamp

### DIFF
--- a/library/Backend/ElasticSearch.php
+++ b/library/Backend/ElasticSearch.php
@@ -131,30 +131,21 @@ class ElasticSearch implements SearchBackendInterface {
             return $params;
         }
 
-        $rangeFilter = [];
+        $rangeFilter = [
+            'range' => [
+                'added' => []
+            ]
+        ];
 
         if ($from) {
-            $rangeFilter['gte'] = $from;
+            $rangeFilter['range']['added']['gte'] = $from;
         }
 
         if ($to) {
-            $rangeFilter['lte'] = $to;
+            $rangeFilter['range']['added']['lte'] = $to;
         }
 
-        $params['body'] = [
-            'query' => [
-                'filtered' => [
-                    'query' => [
-                        'match' => $params['body']['query']['match']
-                    ],
-                    'filter' => [
-                        'range' => [
-                            'added' => $rangeFilter
-                        ]
-                    ]
-                ]
-            ]
-        ];
+        $params['body']['query']['filtered']['filter'][] = $rangeFilter;
 
         return $params;
     }

--- a/library/Dsl/Parser.php
+++ b/library/Dsl/Parser.php
@@ -26,17 +26,17 @@ class Parser {
      *
      * @var array
      */
-    private static $validQueryDslExpressions = array(
+    private static $validQueryDslExpressions = [
         '$or'       => true,
         '$and'      => true,
-    );
+    ];
 
     /**
      * Valid operators for metadata queries
      *
      * @var array
      */
-    private static $validQueryDslOperators = array(
+    private static $validQueryDslOperators = [
         '$gt'       => true,
         '$gte'      => true,
         '$in'       => true,
@@ -45,7 +45,7 @@ class Parser {
         '$ne'       => true,
         '$nin'      => true,
         '$wildcard' => false, // We want to support this - but not built yet
-    );
+    ];
 
     /**
      * Parse (and validate) a DSL search query.
@@ -91,7 +91,7 @@ class Parser {
      * @throws \InvalidArgumentException
      */
     private static function normalizeExpression(array $ast) {
-        $result = array();
+        $result = [];
 
         if (count($ast) === 1) {
             // The expression we are normalizing already only have one element.
@@ -119,15 +119,15 @@ class Parser {
                 // using normalizeField. Normalize field can change the key of
                 // the field, if it lifts our $and's.
                 list($key, $value) = self::normalizeField($key, $ast[$key]);
-                $result = array($key => $value);
+                $result = [$key => $value];
             }
         } else {
             // The expression wasn't normalized to only have one term in each
             // expression, so we convert it into a $and-expression where each
             // clause consists of one term. These terms are normalized too.
-            $result = array('$and' => []);
+            $result = ['$and' => []];
             foreach ($ast AS $key => $node) {
-                $result['$and'][] = self::normalizeExpression(array($key => $node));
+                $result['$and'][] = self::normalizeExpression([$key => $node]);
             }
         }
 
@@ -157,7 +157,7 @@ class Parser {
                 throw new InvalidArgumentException('No operations defined for the criteria on "' . $field . '"');
             }
 
-            $result = array();
+            $result = [];
             // Iterate over the operations on the field
             foreach ($value AS $key => $value) {
                 if (substr($key, 0, 1) !== "$") {
@@ -173,7 +173,7 @@ class Parser {
                 }
 
                 // Do some type-checking on the value for the operation
-                if (in_array($key, array('$in', '$nin'))) {
+                if (in_array($key, ['$in', '$nin'])) {
                     // If the operator is $in or $nin (not in), we check that
                     // the argument given is actually an array
                     if (!is_array($value)) {
@@ -188,7 +188,7 @@ class Parser {
                 }
 
                 // Then simply lift the operator out to a seperate operation.
-                $result[] = array($field => array($key => $value));
+                $result[] = [$field => [$key => $value]];
             }
 
             if (count($result) === 1) {

--- a/library/Dsl/Transformations/ElasticSearchDsl.php
+++ b/library/Dsl/Transformations/ElasticSearchDsl.php
@@ -70,11 +70,11 @@ class ElasticSearchDsl implements DslTransformationInterface {
         switch(true) {
             case $query instanceof Conjunction:
                 // We map conjunctions into `and`-filters.
-                return array('and' => array_map([$this, '_transform'], $query->getArrayCopy()));
+                return ['and' => array_map([$this, '_transform'], $query->getArrayCopy())];
 
             case $query instanceof Disjunction:
                 // ... and disjunctions into `or`-filters
-                return array('or' => array_map([$this, '_transform'], $query->getArrayCopy()));
+                return ['or' => array_map([$this, '_transform'], $query->getArrayCopy())];
 
             case $query instanceof Field:
                 // We have a field, so let's look at the type of comparison we
@@ -86,61 +86,61 @@ class ElasticSearchDsl implements DslTransformationInterface {
                 switch (true) {
                     case $comparison instanceof Equals:
                         // Equality we make into `match`-queries
-                        return array('query' => array('match' =>
-                            array($field => $comparison->value())
-                        ));
+                        return ['query' => ['match' =>
+                            [$field => $comparison->value()]
+                        ]];
 
                     case $comparison instanceof NotEquals:
                         // And not-equals we make into a not-filter with a
                         // `match`-filter inside it
-                        return array('not' => array('query' => array('match' =>
-                            array($field => $comparison->value())
-                        )));
+                        return ['not' => ['query' => ['match' =>
+                            [$field => $comparison->value()]
+                        ]]];
 
                     case $comparison instanceof In:
                         // We make in-set checks into a `terms`-filter
-                        return array('terms' => array(
+                        return ['terms' => [
                             $field => $comparison->value(),
-                        ));
+                        ]];
 
                     case $comparison instanceof NotIn:
                         // And likewise a not-in into a `not` filter wrapping a
                         // `terms`-filter.
-                        return array('not' => array('terms' => array(
+                        return ['not' => ['terms' => [
                             $field => $comparison->value(),
-                        )));
+                        ]]];
 
                     case $comparison instanceof LessThan:
                         // Less-than we do with a `range`-filter
-                        return array('range' => array(
-                            $field => array(
+                        return ['range' => [
+                            $field => [
                                 'lt' => $comparison->value(),
-                            ),
-                        ));
+                            ],
+                        ]];
 
                     case $comparison instanceof LessThanEquals:
                         // And like-wise with less-than-or-equals
-                        return array('range' => array(
-                            $field => array(
+                        return ['range' => [
+                            $field => [
                                 'lte' => $comparison->value(),
-                            ),
-                        ));
+                            ],
+                        ]];
 
                     case $comparison instanceof GreaterThan:
                         // ... and with greater-than
-                        return array('range' => array(
-                            $field => array(
+                        return ['range' => [
+                            $field => [
                                 'gt' => $comparison->value(),
-                            ),
-                        ));
+                            ],
+                        ]];
 
                     case $comparison instanceof GreaterThanEquals:
                         // and unsurprisingly also with greater-than-or-equals
-                        return array('range' => array(
-                            $field => array(
+                        return ['range' => [
+                            $field => [
                                 'gte' => $comparison->value(),
-                            ),
-                        ));
+                            ],
+                        ]];
                 }
         }
     }

--- a/library/Dsl/Transformations/ElasticSearchDsl.php
+++ b/library/Dsl/Transformations/ElasticSearchDsl.php
@@ -29,7 +29,7 @@ class ElasticSearchDsl implements DslTransformationInterface {
      * @return array
      */
     public function transform(AstNode $query) {
-        $transformed = $this->_transform($query);
+        $transformed = $this->transformAstToQuery($query);
 
         switch (key($transformed)) {
             // A simple query was returned, use it for the query part
@@ -45,8 +45,8 @@ class ElasticSearchDsl implements DslTransformationInterface {
                 ];
 
             default:
-                // A filter was returned from _transform. Add it to the
-                // list of filters and set an empty query.
+                // A filter was returned from transformAstToQuery. Add it
+                // to the list of filters and set an empty query.
                 return [
                     'query' => [
                         'filtered' => [
@@ -66,15 +66,15 @@ class ElasticSearchDsl implements DslTransformationInterface {
      * @param Imbo\MetadataSearch\Interfaces\DslAstInterface $query
      * @return array
      */
-    public function _transform(AstNode $query) {
-        switch(true) {
+    public function transformAstToQuery(AstNode $query) {
+        switch (true) {
             case $query instanceof Conjunction:
                 // We map conjunctions into `and`-filters.
-                return ['and' => array_map([$this, '_transform'], $query->getArrayCopy())];
+                return ['and' => array_map([$this, 'transformAstToQuery'], $query->getArrayCopy())];
 
             case $query instanceof Disjunction:
                 // ... and disjunctions into `or`-filters
-                return ['or' => array_map([$this, '_transform'], $query->getArrayCopy())];
+                return ['or' => array_map([$this, 'transformAstToQuery'], $query->getArrayCopy())];
 
             case $query instanceof Field:
                 // We have a field, so let's look at the type of comparison we

--- a/library/EventListener/MetadataOperations.php
+++ b/library/EventListener/MetadataOperations.php
@@ -258,6 +258,10 @@ class MetadataOperations implements ListenerInterface {
         // set the page param to 0 before triggering db.images.load
         $params->set('page', 0);
 
+        // Unset date range parameters
+        $params->remove('to');
+        $params->remove('from');
+
         // Trigger image loading from imbo DB
         $event->getManager()->trigger('db.images.load');
         $responseModel = $event->getResponse()->getModel();

--- a/library/Model/BackendResponse.php
+++ b/library/Model/BackendResponse.php
@@ -15,7 +15,7 @@ class BackendResponse implements ModelInterface {
      *
      * @var string[]
      */
-    private $imageIdentifiers = array();
+    private $imageIdentifiers = [];
 
     /**
      * Query hits

--- a/library/Resource/Search.php
+++ b/library/Resource/Search.php
@@ -23,10 +23,10 @@ class Search implements ResourceInterface {
      * {@inheritdoc}
      */
     public static function getSubscribedEvents() {
-        return array(
+        return [
             'search.get' => 'search',
             'search.head' => 'search',
-        );
+        ];
     }
 
     /**

--- a/tests/behat/bootstrap/RESTContext.php
+++ b/tests/behat/bootstrap/RESTContext.php
@@ -44,7 +44,7 @@ class RESTContext implements Context
      *
      * @var array
      */
-    protected $requestHeaders = array();
+    protected $requestHeaders = [];
 
     /**
      * Class constructor
@@ -71,17 +71,17 @@ class RESTContext implements Context
      * Create a new HTTP client
      */
     private function createClient() {
-        $this->imbo = new ImboClient($this->params['url'], array(
+        $this->imbo = new ImboClient($this->params['url'], [
             'publicKey' => 'publickey',
             'privateKey' => 'privatekey',
-        ));
+        ]);
 
         $eventDispatcher = $this->imbo->getEventDispatcher();
         $eventDispatcher->addSubscriber($this->history);
 
-        $defaultHeaders = array(
+        $defaultHeaders = [
             'X-Test-Session-Id' => self::$testSessionId,
-        );
+        ];
 
         $this->imbo->setDefaultHeaders($defaultHeaders);
     }
@@ -168,7 +168,7 @@ class RESTContext implements Context
                             $router,
                             $httpdLog);
 
-        $output = array();
+        $output = [];
         exec($command, $output);
 
         return (int) $output[0];

--- a/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/ParserTest.php
+++ b/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/ParserTest.php
@@ -18,42 +18,42 @@ use Imbo\MetadataSearch\Dsl\Parser,
 
 class ParserTest extends \PHPUnit_Framework_TestCase {
     public function getValidDslQueries() {
-        return array(
-            'empty string' => array(
+        return [
+            'empty string' => [
                 'query' => '',
                 'expected' => new Conjunction([]),
-            ),
-            'minimal text' => array(
+            ],
+            'minimal text' => [
                 'query' => '{}',
                 'expected' => new Conjunction([]),
-            ),
-            'minimal associative array' => array(
+            ],
+            'minimal associative array' => [
                 'query' => [],
                 'expected' => new Conjunction([]),
-            ),
-            'already lowercased' => array(
-                'original' => array('foo' => 'bar'),
+            ],
+            'already lowercased' => [
+                'original' => ['foo' => 'bar'],
                 'expected' => new Field('foo', new Equals('bar')),
-            ),
-            'mixed case' => array(
-                'original' => array('Foo' => 'Bar'),
+            ],
+            'mixed case' => [
+                'original' => ['Foo' => 'Bar'],
                 'expected' => new Field('Foo', new Equals('Bar')),
-            ),
-            'implicit $and at the root, as string' => array(
+            ],
+            'implicit $and at the root, as string' => [
                 'original' => '{"foo": "bar", "baz": "blargh"}',
                 'expected' => new Conjunction([
                                   new Field('foo', new Equals('bar')),
                                   new Field('baz', new Equals('blargh'))
                               ]),
-            ),
-            'root as explicit $and, as string' => array(
+            ],
+            'root as explicit $and, as string' => [
                 'original' => '{"$and": [{"foo": "bar"}, {"baz": "blargh"}]}',
                 'expected' => new Conjunction([
                                   new Field('foo', new Equals('bar')),
                                   new Field('baz', new Equals('blargh'))
                               ]),
-            ),
-            'implicit $and inside an $or, as string' => array(
+            ],
+            'implicit $and inside an $or, as string' => [
                 'original' => '{"$or": [{"foo": "bar"}, {"bar": "baz", "baz": "blargh"}]}',
                 'expected' => new Disjunction([
                                   new Field('foo', new Equals('bar')),
@@ -62,26 +62,26 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
                                       new Field('baz', new Equals('blargh'))
                                   ])
                               ]),
-            ),
-            'a single operator on a field' => array(
+            ],
+            'a single operator on a field' => [
                 'original' => '{"foo": {"$gt": 5}}',
                 'expected' => new Field('foo', new GreaterThan(5)),
-            ),
-            'multiple operators on a field' => array(
+            ],
+            'multiple operators on a field' => [
                 'original' => '{"foo": {"$gt": 5, "$lte": 15}}',
                 'expected' => new Conjunction([
                                   new Field('foo', new GreaterThan(5)),
                                   new Field('foo', new LessThanEquals(15)),
                               ])
-            ),
-            'in and not-in is accepted with arrays' => array(
+            ],
+            'in and not-in is accepted with arrays' => [
                 'original' => '{"$or": [{"field": {"$in": [1, 2, 3]}}, {"field": {"$nin": [5, 6 ,7]}}]}',
                 'expected' => new Disjunction([
                                   new Field('field', new In([1, 2, 3])),
                                   new Field('field', new NotIn([5, 6, 7])),
                               ])
-            ),
-            'a larger, more complex query' => array(
+            ],
+            'a larger, more complex query' => [
                 'original' => '{
                                 "name": { "$ne": "Wit" },
                                 "$or": [
@@ -104,57 +104,57 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
                                       ]),
                                   ]),
                               ]),
-            ),
-        );
+            ],
+        ];
     }
 
     public function getInvalidDslQueries() {
-        return array(
-            'invalid json' => array(
+        return [
+            'invalid json' => [
                 'query' => 'not json',
                 'message' => 'Query must be valid JSON',
-            ),
-            'query is a string' => array(
+            ],
+            'query is a string' => [
                 'query' => '"a string"',
                 'message' => 'Query must be a JSON object or array',
-            ),
-            'query is a number' => array(
+            ],
+            'query is a number' => [
                 'query' => 3.1415,
                 'message' => 'Query must be a JSON object or array',
-            ),
-            'unsupported expression' => array(
+            ],
+            'unsupported expression' => [
                 'query' => '{"$nor": [{"foo": "bar"}, {"baz": "blargh"}]}',
                 'message' => 'Expressions of the type $nor not allowed. Only allowed expressions are: $or, $and',
-            ),
-            'using a operator as an expression' => array(
+            ],
+            'using a operator as an expression' => [
                 'query' => '{"$in": [1, 2, 3]}',
                 'message' => 'Expressions of the type $in not allowed. Only allowed expressions are: $or, $and',
-            ),
-            'using an operator that is not supported ($regex)' => array(
-                'query' => array('category' => array('$regex' => '(foo|bar|baz)')),
+            ],
+            'using an operator that is not supported ($regex)' => [
+                'query' => ['category' => ['$regex' => '(foo|bar|baz)']],
                 'message' => 'Operator of the type $regex not allowed',
-            ),
-            'specifying a non-array for a operator' => array(
+            ],
+            'specifying a non-array for a operator' => [
                 'query' => '{"$or": 3}',
                 'message' => 'Contents of the $or-expression is not an array',
-            ),
-            'not specifing an operator on a field' => array(
+            ],
+            'not specifing an operator on a field' => [
                 'query' => '{"category": []}',
                 'message' => 'No operations defined for the criteria on "category"',
-            ),
-            'performing a exact-embedded document search' => array(
+            ],
+            'performing a exact-embedded document search' => [
                 'query' => '{"category": {"foo": "bar", "baz": "blargh"}}',
                 'message' => 'Imbo does not support exact matches on embedded documents. Please use dot-syntax instead',
-            ),
-            'performing a less-than on an array' => array(
+            ],
+            'performing a less-than on an array' => [
                 'query' => '{"foo": {"$gt": [1, 2, 3]}}',
                 'message' => 'The operator $gt must not be called with an array',
-            ),
-            'performing a in on a string' => array(
+            ],
+            'performing a in on a string' => [
                 'query' => '{"foo": {"$in": "a string"}}',
                 'message' => 'The operator $in must be called with an array',
-            ),
-        );
+            ],
+        ];
     }
 
     /**

--- a/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/Transformations/ElasticSearchDslTest.php
+++ b/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/Transformations/ElasticSearchDslTest.php
@@ -12,24 +12,35 @@ class ElasticSearchDslTest extends \PHPUnit_Framework_TestCase {
         $this->transformation = new ElasticSearchDsl();
     }
 
+    protected function buildExpectedQuery($query = [], $filters = []) {
+        return [
+            'query' => [
+                'filtered' => [
+                    'query' => $query,
+                    'filter' => $filters
+                ]
+            ]
+        ];
+    }
+
     public function getQueries() {
-        return array(
-            'a simple query' => array(
+        return [
+            'a simple query' => [
                 'query' => '{"foo": "bar"}',
-                'expected' => array('query' => array('match' => array('metadata.foo' => 'bar'))),
-            ),
-            'another simple query' => array(
+                'expected' => $this->buildExpectedQuery(['match' => ['metadata.foo' => 'bar']], []),
+            ],
+            'another simple query' => [
                 'query' => '{"foo": "bar", "baz": "blargh"}',
-                'expected' => array('filter' => array('and' => array(
-                                                        array('query' => array('match' => array('metadata.foo' => 'bar'))),
-                                                        array('query' => array('match' => array('metadata.baz' => 'blargh'))),
-                                                    ))),
-            ),
-            'a simple less-than query' => array(
+                'expected' => $this->buildExpectedQuery([], [['and' => [
+                                                                ['query' => ['match' => ['metadata.foo' => 'bar']]],
+                                                                ['query' => ['match' => ['metadata.baz' => 'blargh']]],
+                                                            ]]]),
+            ],
+            'a simple less-than query' => [
                 'query' => '{"foo": {"$lt": 5}}',
-                'expected' => array('filter' => array('range' => array('metadata.foo' => array('lt' => 5)))),
-            ),
-        );
+                'expected' => $this->buildExpectedQuery([], [['range' => ['metadata.foo' => ['lt' => 5]]]]),
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
Add support for filtering images based on the added timestamp. This feature was left out in the initial version, but the result set was still filtered if `from` and `to` was provided because of the `db.images.load` event handler using these parameters when querying the DB.