### PR TITLE
Use the user instead of the public key to lookup/store image data

### DIFF
--- a/library/EventListener/MetadataOperations.php
+++ b/library/EventListener/MetadataOperations.php
@@ -61,14 +61,14 @@ class MetadataOperations implements ListenerInterface {
         $image = new ImageModel();
 
         $event->getDatabase()->load(
-            $event->getRequest()->getPublicKey(),
+            $event->getRequest()->getUser(),
             $imageIdentifier,
             $image
         );
 
         // Get image metadata
         $metadata = $event->getDatabase()->getMetadata(
-            $event->getRequest()->getPublicKey(),
+            $event->getRequest()->getUser(),
             $imageIdentifier
         );
 
@@ -187,7 +187,7 @@ class MetadataOperations implements ListenerInterface {
     public function delete(EventInterface $event) {
         $request = $event->getRequest();
 
-        $this->backend->delete($request->getPublicKey(), $request->getImageIdentifier());
+        $this->backend->delete($request->getUser(), $request->getImageIdentifier());
     }
 
     /**

--- a/tests/behat/features/elasticsearch.feature
+++ b/tests/behat/features/elasticsearch.feature
@@ -5,14 +5,14 @@ Feature: Use elasticsearch as search backend for the metadata search pluin
     Background:
         Given I use "publickey" and "privatekey" for public and private keys
         And I add the following images to Imbo:
-            | file          | metadata                              |
+            | file          | metadata                                        |
             | red-panda     | {"sort":1, "animal":"Red Panda", "color":"red"} |
             | giant-panda   | {"sort":2, "animal":"Giant Panda"}              |
             | hedgehog      | {"sort":3, "animal":"Hedgehog"}                 |
             | kitten        | {"sort":4, "animal":"Cat", "color":"red"}       |
         And I use "user1" and "privatekey" for public and private keys
         And I add the following images to Imbo:
-            | file          | metadata                                      |
+            | file          | metadata                                        |
             | prairie-dog   | {"sort":5, "animal":"Dog"}                      |
         And I have flushed the elasticsearch transaction log
 
@@ -79,7 +79,7 @@ Feature: Use elasticsearch as search backend for the metadata search pluin
         And I should get <images> in the image response list
 
         Examples:
-        | sort                           | images                                                    |
+        | sort                           | images           |
         | {"size":"asc"}                 | kitten,red-panda |
         | {"size":"desc"}                | red-panda,kitten |
         | {"width":"desc","size":"desc"} | kitten,red-panda |


### PR DESCRIPTION
To make this compatible with Imbo 2.0, we'll need to use the user instead of the public key for storing metadata as well as retrieving metadata from the database. This fixes this.