### PR TITLE
Fix image deletion bug

### DIFF
--- a/library/Backend/ElasticSearch.php
+++ b/library/Backend/ElasticSearch.php
@@ -49,7 +49,11 @@ class ElasticSearch implements SearchBackendInterface {
      * {@inheritdoc}
      */
     public function delete($user, $imageIdentifier) {
-        $params = $this->prepareParams($imageIdentifier);
+        $params = [
+            'index' => $this->getIndexName(),
+            'type' => 'metadata',
+            'id' => $imageIdentifier
+        ];
 
         try {
             return !!$this->client->delete($params);

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -139,7 +139,7 @@ class FeatureContext extends RESTContext implements Context, SnippetAcceptingCon
     /**
      * @Then Elasticsearch should not have metadata for the :imageName image
      */
-    public function elasticsearchShouldNotMetadataFor($imageName)
+    public function elasticsearchShouldNotHaveMetadataFor($imageName)
     {
         $publicKey = 'publickey';
 

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -126,9 +126,9 @@ class FeatureContext extends RESTContext implements Context, SnippetAcceptingCon
     }
 
     /**
-     * @Then Elasticsearch should not have metadata for the :imageName image
+     * @Then Elasticsearch should have an empty metadata object for the :imageName image
      */
-    public function elasticsearchShouldNotHaveMetadataFor($imageName)
+    public function elasticsearchShouldHaveAnEmptyMetadataObjectFor($imageName)
     {
         $this->elasticsearchShouldHaveTheFollowingMetadataFor(
             $imageName,
@@ -137,11 +137,42 @@ class FeatureContext extends RESTContext implements Context, SnippetAcceptingCon
     }
 
     /**
+     * @Then Elasticsearch should not have metadata for the :imageName image
+     */
+    public function elasticsearchShouldNotMetadataFor($imageName)
+    {
+        $publicKey = 'publickey';
+
+        $params = [
+            'index' => 'metadatasearch_integration',
+            'type' => 'metadata',
+            'id' => $this->images[$imageName]
+        ];
+
+        $exception;
+        try {
+            $this->elasticsearch->get($params);
+        } catch (Exception $e) {
+            $exception = $e;
+        }
+
+        Assertion::isInstanceOf($exception, 'Elasticsearch\Common\Exceptions\Missing404Exception');
+    }
+
+    /**
      * @When I delete metadata from the :imageName image
      */
     public function deleteMetadataFromImage($imageName)
     {
         $this->imbo->deleteMetadata($this->images[$imageName]);
+    }
+
+    /**
+     * @When I delete the :imageName image
+     */
+    public function deleteImage($imageName)
+    {
+        $this->imbo->deleteImage($this->images[$imageName]);
     }
 
     /**

--- a/tests/behat/features/elasticsearch.feature
+++ b/tests/behat/features/elasticsearch.feature
@@ -28,11 +28,17 @@ Feature: Use elasticsearch as search backend for the metadata search pluin
         {"foo":"bar"}
         """
 
+    Scenario: Deleting an image
+        Given I use "publickey" and "privatekey" for public and private keys
+        When I delete the "giant-panda" image
+        Then I should get a response with "200 OK"
+        And Elasticsearch should not have metadata for the "giant-panda" image
+
     Scenario: Deleting metadata
         Given I use "publickey" and "privatekey" for public and private keys
         When I delete metadata from the "giant-panda" image
         Then I should get a response with "200 OK"
-        And Elasticsearch should not have metadata for the "giant-panda" image
+        And Elasticsearch should have an empty metadata object for the "giant-panda" image
 
     Scenario: Patch metadata
         Given I use "publickey" and "privatekey" for public and private keys


### PR DESCRIPTION
This PR fix a bug in the delete image handler and adds a test ensuring that metadata is actually removed from the ES index when an image is deleted in imbo.