### PR TITLE
Added support for searching for empty values, and for using the $exists-operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 cache:
   directories:
@@ -26,15 +27,15 @@ services:
   - elasticsearch
 
 before_install:
-  - sudo add-apt-repository -y ppa:moti-p/cc
-  - sudo apt-get update
-  - sudo apt-get -y --reinstall install imagemagick
+  - pecl list
+  - php -i
   - printf "\n" | pecl install --force mongo
   - printf "\n" | pecl install --force mongodb
-  - printf "\n" | pecl install --force memcached-2.2.0
-  - printf "\n" | pecl install imagick-3.4.0RC3
+  - printf "\n" | pecl install imagick
 
 before_script:
+  - phpenv config-rm xdebug.ini
+  - echo 'always_populate_raw_post_data = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - "mkdir -p build/logs && touch build/logs/httpd.log"
   - echo "extension = imagick.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,8 @@ before_script:
   - phpenv config-rm xdebug.ini
   - echo 'always_populate_raw_post_data = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - "mkdir -p build/logs && touch build/logs/httpd.log"
-  - echo "extension = imagick.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - pecl list
+  - php -i
   - composer self-update
   - composer install --prefer-dist
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ Look for values that does not appear in the specified set.
 {"styles":{"$nin":["Pilsner"]}}
 ```
 
+#### Field exists - `$exists`
+
+Ensure that a given field does or does not exist.
+
+```js
+{"age":{"$exists":true}}
+```
+
 #### Conjunctions - `$and`
 
 This operator can be used to combine a list of criteria that must all match. It

--- a/library/Dsl/Ast/Comparison/Exists.php
+++ b/library/Dsl/Ast/Comparison/Exists.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Imbo\MetadataSearch\Dsl\Ast\Comparison;
+
+use Imbo\MetadataSearch\Interfaces\DslAstComparisonInterface AS AstComparison,
+    Imbo\MetadataSearch\Dsl\Ast\Comparison\Base;
+
+/**
+ * A comparison for equality against the stored value
+ *
+ * @author Morten Fangel <fangel@sevengoslings.net>
+ */
+class Exists extends Base implements AstComparison {}

--- a/library/Dsl/Parser.php
+++ b/library/Dsl/Parser.php
@@ -13,7 +13,8 @@ use Imbo\Exception\InvalidArgumentException,
     Imbo\MetadataSearch\Dsl\Ast\Comparison\LessThan,
     Imbo\MetadataSearch\Dsl\Ast\Comparison\LessThanEquals,
     Imbo\MetadataSearch\Dsl\Ast\Comparison\GreaterThan,
-    Imbo\MetadataSearch\Dsl\Ast\Comparison\GreaterThanEquals;
+    Imbo\MetadataSearch\Dsl\Ast\Comparison\GreaterThanEquals,
+    Imbo\MetadataSearch\Dsl\Ast\Comparison\Exists;
 
 /**
  * Imbo DSL parser
@@ -44,6 +45,7 @@ class Parser {
         '$lte'      => true,
         '$ne'       => true,
         '$nin'      => true,
+        '$exists'   => true,
         '$wildcard' => false, // We want to support this - but not built yet
     ];
 
@@ -179,6 +181,12 @@ class Parser {
                     if (!is_array($value)) {
                         throw new InvalidArgumentException('The operator ' . $key . ' must be called with an array', 400);
                     }
+                } else if (in_array($key, ['$exists'])) {
+                    // If the operator is $exists, we check that the argument
+                    // given is a boolean
+                    if (!is_bool($value)) {
+                        throw new InvalidArgumentException('The operator ' . $key . ' must be called with an boolean', 400);
+                    }
                 } else {
                     // The operator is not working on sets, we the value can't
                     // be an array
@@ -254,6 +262,8 @@ class Parser {
                     return new GreaterThan($value);
                 case '$gte':
                     return new GreaterThanEquals($value);
+                case '$exists':
+                    return new Exists($value);
             }
         } else {
             return new Equals($value);

--- a/library/Dsl/Transformations/ElasticSearchDsl.php
+++ b/library/Dsl/Transformations/ElasticSearchDsl.php
@@ -88,21 +88,21 @@ class ElasticSearchDsl implements DslTransformationInterface {
                     case $comparison instanceof Equals:
                         // Equality we make into `match`-queries
                         if ($comparison->value() === '') {
-                          // Elastic doesn't support matches against empty
-                          // values. Instead we can do something equiv. to it
-                          // using the wildcard- and exists-operator
-                          return ['bool' => [
-                              'must_not' => [
-                                  'wildcard' => [
-                                      $field => '*',
-                                  ],
-                              ],
-                              'must' => [
-                                  ['exists' => [
-                                      'field' => $field,
-                                  ]],
-                              ],
-                          ]];
+                            // Elastic doesn't support matches against empty
+                            // values. Instead we can do something equiv. to it
+                            // using the wildcard- and exists-operator
+                            return ['bool' => [
+                                'must_not' => [
+                                    'wildcard' => [
+                                        $field => '*',
+                                    ],
+                                ],
+                                'must' => [
+                                    ['exists' => [
+                                        'field' => $field,
+                                    ]],
+                                ],
+                            ]];
                         }
 
                         return ['match' =>
@@ -114,13 +114,13 @@ class ElasticSearchDsl implements DslTransformationInterface {
                         // `must_not`-clause containing a `match`-qyuery inside
                         // it
                         if ($comparison->value() === '') {
-                          // Except if you are trying to find something that
-                          // isn't empty - because Elastic doesn't support that
-                          // so we use a wildcard-operator to do something
-                          // equivalent
-                          return ['wildcard' => [
-                              $field => '*',
-                          ]];
+                            // Except if you are trying to find something that
+                            // isn't empty - because Elastic doesn't support that
+                            // so we use a wildcard-operator to do something
+                            // equivalent
+                            return ['wildcard' => [
+                                $field => '*',
+                            ]];
                         }
 
                         return ['bool' => ['must_not' => ['match' =>

--- a/tests/behat/features/elasticsearch.feature
+++ b/tests/behat/features/elasticsearch.feature
@@ -5,15 +5,15 @@ Feature: Use elasticsearch as search backend for the metadata search pluin
     Background:
         Given I use "publickey" and "privatekey" for public and private keys
         And I add the following images to the user named "user":
-            | file          | metadata                                                      |
-            | kitten        | {"sort":4, "animal":"Cat", "color":"red", "age": 5}           |
-            | red-panda     | {"sort":1, "animal":"Red Panda", "color":"red", "age": 7}     |
-            | giant-panda   | {"sort":2, "animal":"Giant Panda", "color":"white", "age": 9} |
-            | hedgehog      | {"sort":3, "animal":"Hedgehog", "color": "brown", "age": 2}   |
+            | file          | metadata                                                                  |
+            | kitten        | {"sort":4, "animal":"Cat", "color":"red", "age": 5, "favorite": "yes"}    |
+            | red-panda     | {"sort":1, "animal":"Red Panda", "color":"red", "age": 7, "favorite": ""} |
+            | giant-panda   | {"sort":2, "animal":"Giant Panda", "color":"white", "age": 9}             |
+            | hedgehog      | {"sort":3, "animal":"Hedgehog", "color": "brown", "age": 2}               |
         And I use "user2" and "privatekey" for public and private keys
         And I add the following images to the user named "user2":
-            | file          | metadata                                                      |
-            | prairie-dog   | {"sort":5, "animal":"Dog", "color":"brown", "age": 4}         |
+            | file          | metadata                                                                  |
+            | prairie-dog   | {"sort":5, "animal":"Dog", "color":"brown", "age": 4}                     |
         And I have flushed the elasticsearch transaction log
 
     Scenario: Updating metadata
@@ -81,6 +81,10 @@ Feature: Use elasticsearch as search backend for the metadata search pluin
         | {"age": {"$lte": 5}}                         | 1    | 20    | hedgehog,kitten       | 2    |
         | {"age": {"$gt": 7}}                          | 1    | 20    | giant-panda           | 1    |
         | {"age": {"$gte": 7}}                         | 1    | 20    | red-panda,giant-panda | 2    |
+        | {"favorite": ""}                             | 1    | 20    | red-panda             | 1    |
+        | {"favorite": {"$ne": ""}}                    | 1    | 20    | kitten                | 1    |
+        | {"favorite": {"$exists": true}}              | 1    | 20    | red-panda,kitten      | 2    |
+        | {"favorite": {"$exists": false}}             | 1    | 20    | giant-panda,hedgehog  | 2    |
 
     Scenario Outline: Search on sub-object in descending order using metadata queries and pagination
         Given I use "publickey" and "privatekey" for public and private keys

--- a/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/ParserTest.php
+++ b/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/ParserTest.php
@@ -13,7 +13,8 @@ use Imbo\MetadataSearch\Dsl\Parser,
     Imbo\MetadataSearch\Dsl\Ast\Comparison\LessThan,
     Imbo\MetadataSearch\Dsl\Ast\Comparison\LessThanEquals,
     Imbo\MetadataSearch\Dsl\Ast\Comparison\GreaterThan,
-    Imbo\MetadataSearch\Dsl\Ast\Comparison\GreaterThanEquals;
+    Imbo\MetadataSearch\Dsl\Ast\Comparison\GreaterThanEquals,
+    Imbo\MetadataSearch\Dsl\Ast\Comparison\Exists;
 
 
 class ParserTest extends \PHPUnit_Framework_TestCase {
@@ -80,6 +81,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
                                   new Field('field', new In([1, 2, 3])),
                                   new Field('field', new NotIn([5, 6, 7])),
                               ])
+            ],
+            'exists is accepted with booleans' => [
+                'original' => '{"foo": {"$exists": true}}',
+                'expected' => new Field('foo', new Exists(true))
             ],
             'a larger, more complex query' => [
                 'original' => '{
@@ -154,6 +159,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
                 'query' => '{"foo": {"$in": "a string"}}',
                 'message' => 'The operator $in must be called with an array',
             ],
+            'performing an exists on a string' => [
+                'query' => '{"foo": {"$exists": "yes"}}',
+                'message' => 'The operator $exists must be called with an boolean'
+            ]
         ];
     }
 

--- a/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/Transformations/ElasticSearchDslTest.php
+++ b/tests/phpunit/ImboMetadataSearchUnitTest/Dsl/Transformations/ElasticSearchDslTest.php
@@ -79,6 +79,67 @@ class ElasticSearchDslTest extends \PHPUnit_Framework_TestCase {
                     ]
                 ]
             ],
+            'Searching for empty strings' => [
+                'query' => '{"foo": ""}',
+                'expected' => [
+                    'query' => [
+                        'bool' => [
+                            'must_not' => [
+                                'wildcard' => [
+                                    'metadata.foo' => '*'
+                                ],
+                            ],
+                            'must' => [
+                                ['exists' => [
+                                    'field' => 'metadata.foo',
+                                ]],
+                            ]
+                        ],
+                    ],
+                ],
+            ],
+            'Searching for not-empty strings' => [
+                'query' => '{"foo": { "$ne": "" }}',
+                'expected' => [
+                    'query' => [
+                        'bool' => [
+                            'must' => [
+                                ['wildcard' => [
+                                    'metadata.foo' => '*'
+                                ]],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'Searching for existing fields' => [
+                'query' => '{"foo": {"$exists": true}}',
+                'expected' => [
+                    'query' => [
+                        'bool' => [
+                            'must' => [
+                                ['exists' => [
+                                    'field' => 'metadata.foo'
+                                ]],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'Searching for non-existing fields' => [
+                'query' => '{"foo": { "$exists": false }}',
+                'expected' => [
+                    'query' => [
+                        'bool' => [
+                            'must_not' => [
+                                'exists' => [
+                                    'field' => 'metadata.foo'
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
             'a terribly complex query' => [
                 'query' => '{
                     "name": {"$ne": "Wit"},


### PR DESCRIPTION
We ran into some use-cases where we wanted to be able to find images based on a couple of different (but similar) criteria:

* Does a given field exist in the metadata or not (so the `$exists`-operator in Mongo's Query DSL)
* Does a given field contain a value (i.e. not the empty string) or not.

The latter is caused by Elastic not supporting matches against the empty string. 

So I added support for the `$exists`-operator and found a way to perform queries that matches when a field is or is-not empty that I've added as special cases for the equality and not-equality comparisons.

I've updated the test-cases to also check that the filters work as expected.